### PR TITLE
Add Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BDT Tutorial
 Hands-on boosted decision tree tutorial (using [XGBoost](https://xgboost.readthedocs.io/en/latest/)) for [September 2017 Fermilab Machine Learning Group Meeting](https://indico.fnal.gov/event/15356/)
 
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/k-woodruff/bdt-tutorial/master)
 [![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/k-woodruff/bdt-tutorial/tree/master/)
 
 ## Authors

--- a/bdt_tutorial.ipynb
+++ b/bdt_tutorial.ipynb
@@ -90,9 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -140,13 +138,13 @@
     }
    ],
    "source": [
-    "print 'Size of data: {}'.format(data.shape)\n",
-    "print 'Number of events: {}'.format(data.shape[0])\n",
-    "print 'Number of columns: {}'.format(data.shape[1])\n",
+    "print('Size of data: {}'.format(data.shape))\n",
+    "print('Number of events: {}'.format(data.shape[0]))\n",
+    "print('Number of columns: {}'.format(data.shape[1]))\n",
     "\n",
-    "print '\\nList of features in dataset:'\n",
+    "print ('\\nList of features in dataset:')\n",
     "for col in data.columns:\n",
-    "    print col"
+    "    print(col)"
    ]
   },
   {
@@ -161,9 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -177,9 +173,9 @@
    ],
    "source": [
     "# look at column labels --- notice last one is \"Label\" and first is \"EventId\" also \"Weight\"\n",
-    "print 'Number of signal events: {}'.format(len(data[data.Label == 's']))\n",
-    "print 'Number of background events: {}'.format(len(data[data.Label == 'b']))\n",
-    "print 'Fraction signal: {}'.format(len(data[data.Label == 's'])/(float)(len(data[data.Label == 's']) + len(data[data.Label == 'b'])))"
+    "print('Number of signal events: {}'.format(len(data[data.Label == 's'])))\n",
+    "print('Number of background events: {}'.format(len(data[data.Label == 'b'])))\n",
+    "print('Fraction signal: {}'.format(len(data[data.Label == 's'])/(float)(len(data[data.Label == 's']) + len(data[data.Label == 'b']))))"
    ]
   },
   {
@@ -199,9 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data['Label'] = data.Label.astype('category')"
@@ -229,9 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -247,12 +239,12 @@
     }
    ],
    "source": [
-    "print 'Number of training samples: {}'.format(len(data_train))\n",
-    "print 'Number of testing samples: {}'.format(len(data_test))\n",
+    "print('Number of training samples: {}'.format(len(data_train)))\n",
+    "print('Number of testing samples: {}'.format(len(data_test)))\n",
     "\n",
-    "print '\\nNumber of signal events in training set: {}'.format(len(data_train[data_train.Label == 's']))\n",
-    "print 'Number of background events in training set: {}'.format(len(data_train[data_train.Label == 'b']))\n",
-    "print 'Fraction signal: {}'.format(len(data_train[data_train.Label == 's'])/(float)(len(data_train[data_train.Label == 's']) + len(data_train[data_train.Label == 'b'])))"
+    "print('\\nNumber of signal events in training set: {}'.format(len(data_train[data_train.Label == 's'])))\n",
+    "print('Number of background events in training set: {}'.format(len(data_train[data_train.Label == 'b'])))\n",
+    "print('Fraction signal: {}'.format(len(data_train[data_train.Label == 's'])/(float)(len(data_train[data_train.Label == 's']) + len(data_train[data_train.Label == 'b']))))"
    ]
   },
   {
@@ -269,14 +261,14 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "feature_names = data.columns[1:-2]  # we skip the first and last two columns because they are the ID, weight, and label\n",
-    "train = xgb.DMatrix(data=data_train[feature_names],label=data_train.Label.cat.codes,missing=-999.0,feature_names=feature_names)\n",
-    "test = xgb.DMatrix(data=data_test[feature_names],label=data_test.Label.cat.codes,missing=-999.0,feature_names=feature_names)"
+    "train = xgb.DMatrix(data=data_train[feature_names],label=data_train.Label.cat.codes,\n",
+    "                    missing=-999.0,feature_names=feature_names)\n",
+    "test = xgb.DMatrix(data=data_test[feature_names],label=data_test.Label.cat.codes,\n",
+    "                   missing=-999.0,feature_names=feature_names)"
    ]
   },
   {
@@ -289,9 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -305,10 +295,10 @@
     }
    ],
    "source": [
-    "print 'Number of training samples: {}'.format(train.num_row())\n",
-    "print 'Number of testing samples: {}'.format(test.num_row())\n",
+    "print('Number of training samples: {}'.format(train.num_row()))\n",
+    "print('Number of testing samples: {}'.format(test.num_row()))\n",
     "\n",
-    "print '\\nNumber of signal events in training set: {}'.format(len(np.where(train.get_label())[0]))"
+    "print('\\nNumber of signal events in training set: {}'.format(len(np.where(train.get_label())[0])))"
    ]
   },
   {
@@ -332,9 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "param = {}\n",
@@ -378,9 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "booster = xgb.train(param,train,num_boost_round=num_trees)"
@@ -399,9 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -412,7 +396,7 @@
     }
    ],
    "source": [
-    "print booster.eval(test)"
+    "print(booster.eval(test))"
    ]
   },
   {
@@ -438,9 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -474,8 +456,10 @@
     "\n",
     "# plot signal and background separately\n",
     "plt.figure();\n",
-    "plt.hist(predictions[test.get_label().astype(bool)],bins=np.linspace(0,1,50),histtype='step',color='midnightblue',label='signal');\n",
-    "plt.hist(predictions[~(test.get_label().astype(bool))],bins=np.linspace(0,1,50),histtype='step',color='firebrick',label='background');\n",
+    "plt.hist(predictions[test.get_label().astype(bool)],bins=np.linspace(0,1,50),\n",
+    "         histtype='step',color='midnightblue',label='signal');\n",
+    "plt.hist(predictions[~(test.get_label().astype(bool))],bins=np.linspace(0,1,50),\n",
+    "         histtype='step',color='firebrick',label='background');\n",
     "# make the plot readable\n",
     "plt.xlabel('Prediction from BDT',fontsize=12);\n",
     "plt.ylabel('Events',fontsize=12);\n",
@@ -485,9 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -539,9 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -560,9 +540,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "The feature that was used the most was \"```DER_mass_MMC```. (For this data the \"DER\" prefix is for derived variables, and \"PRI\" is for raw variables.)\n",
     "\n",
@@ -572,9 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -589,8 +565,10 @@
    ],
    "source": [
     "plt.figure();\n",
-    "plt.hist(data_train.DER_mass_MMC[data_train.Label == 's'],bins=np.linspace(0,800,50),histtype='step',color='midnightblue',label='signal');\n",
-    "plt.hist(data_train.DER_mass_MMC[data_train.Label == 'b'],bins=np.linspace(0,800,50),histtype='step',color='firebrick',label='background');\n",
+    "plt.hist(data_train.DER_mass_MMC[data_train.Label == 's'],bins=np.linspace(0,800,50),\n",
+    "         histtype='step',color='midnightblue',label='signal');\n",
+    "plt.hist(data_train.DER_mass_MMC[data_train.Label == 'b'],bins=np.linspace(0,800,50),\n",
+    "         histtype='step',color='firebrick',label='background');\n",
     "\n",
     "plt.xlabel('DER_mass_MMC',fontsize=12);\n",
     "plt.ylabel('Events',fontsize=12);\n",
@@ -607,9 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -624,43 +600,36 @@
    ],
    "source": [
     "plt.figure();\n",
-    "plt.plot(data_train.DER_mass_MMC[data_train.Label == 'b'],data_train.PRI_tau_pt[data_train.Label == 'b'],'o',markersize=2,color='firebrick',markeredgewidth=0,alpha=0.8,label='background');\n",
-    "plt.plot(data_train.DER_mass_MMC[data_train.Label == 's'],data_train.PRI_tau_pt[data_train.Label == 's'],'o',markersize=2,color='mediumblue',markeredgewidth=0,alpha=0.8,label='signal');\n",
+    "plt.plot(data_train.DER_mass_MMC[data_train.Label == 'b'],data_train.PRI_tau_pt[data_train.Label == 'b'],\n",
+    "         'o',markersize=2,color='firebrick',markeredgewidth=0,alpha=0.8,label='background');\n",
+    "plt.plot(data_train.DER_mass_MMC[data_train.Label == 's'],data_train.PRI_tau_pt[data_train.Label == 's'],\n",
+    "         'o',markersize=2,color='mediumblue',markeredgewidth=0,alpha=0.8,label='signal');\n",
     "\n",
     "plt.xlim(0,400);\n",
     "plt.ylim(0,200);\n",
     "plt.xlabel('DER_mass_MMC',fontsize=12);\n",
     "plt.ylabel('PRI_tau_pt',fontsize=12);\n",
-    "plt.legend(frameon=False,numpoints=1,markerscale=2);\n"
+    "plt.legend(frameon=False,numpoints=1,markerscale=2);"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+matplotlib
+numpy
+pandas
+xgboost


### PR DESCRIPTION
@k-woodruff This PR will "Binderize" the repo making it so that anyone can run the Jupyter notebook inside of it from their web browser using [Binder](https://mybinder.org/) without even having to clone the repo.

I have tested this in my fork and after making the print statements Python 3 compliant the notebook can be run with "Run All" and everything will succeed in Binder. 

The "launch Binder" badge in the README is correct for the original repo. The only thing that needs to be done after the PR is accepted is to visit https://mybinder.org/, paste "https://github.com/k-woodruff/bdt-tutorial" into the "GitHub repo or URL" text box and then click "launch". Once the build has completed the repo will be Binderized and ready.

This PR can be squashed and merged --- I don't think there is any real reason to show all the commits, but I'll leave that up to the owner. :)